### PR TITLE
Changement de l'url pour la récupération du plugin Googlemaps.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -12,7 +12,7 @@
     <clobbers target="gmaps.addons" />
   </js-module>
 
-  <dependency id="cordova-plugin-googlemaps" url="https://github.com/mapsplugin/cordova-plugin-googlemaps" />
+  <dependency id="cordova-plugin-googlemaps" url="https://github.com/stubbst/cordova-plugin-googlemaps" />
 
   <!-- android -->
   <platform name="android">


### PR DESCRIPTION
Cleemy mobile se base actuellement sur `stubbst/cordova-plugin-googlemaps` alors que ce plug-in (également utilisé par Cleemy mobile) se basait sur `mapsplugin/cordova-plugin-googlemaps`.
=> pas top

`mapsplugin/cordova-plugin-googlemaps` avait évolué pour se baser sur une nouvelle version de `com.googlemaps.ios` ce qui foutait la merde lors du build.

La différence dans _plugin.xml_ :
 - Dans `mapsplugin/cordova-plugin-googlemaps`
```xml
<dependency id="com.googlemaps.ios" url="https://github.com/mapsplugin/cordova-plugin-googlemaps-sdk" branch="master"  />
```
 - Dans `stubbst/cordova-plugin-googlemaps`
```xml
<dependency id="com.googlemaps.ios" url="https://bitbucket.org/nightstomp/cordova-plugin-googlemaps-sdk.git" commit="master" />
```